### PR TITLE
rpi: add persistent ssh key storage

### DIFF
--- a/buildroot-external/board/raspberrypi/rootfs-overlay/etc/systemd/system/dropbear-persist.service
+++ b/buildroot-external/board/raspberrypi/rootfs-overlay/etc/systemd/system/dropbear-persist.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Prepare and mount persistent dropbear host keys
+Before=dropbear.service
+After=local-fs.target
+Requires=local-fs.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/bin/mkdir -p /data/persist/etc/dropbear
+
+# Generate keys if they don't exist
+ExecStart=/bin/sh -c '[ -f /data/persist/etc/dropbear/dropbear_ed25519_host_key ] || dropbearkey -t ed25519 -f /data/persist/etc/dropbear/dropbear_ed25519_host_key'
+
+# Bind mount the persistent directory
+ExecStart=/bin/mount --bind /data/persist/etc/dropbear /etc/dropbear
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
When the system boots, it generates unique host SSH keys. If they don't persist, they'll be re-generated, which loses any integrity.

Make the SSH keys persistent, so that host keys can be validated. Security FTW!